### PR TITLE
Update README to use Fishjam (rebranding)

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -43,7 +43,7 @@ We use [Playwright](https://playwright.dev/) to run e2e tests.
 
 Use the `npm run e2e` command to run them. You may need to install the browsers using this command: `npx playwright install --with-deps`.
 
-The e2e tests start a Jellyfish instance via Docker and [Testcontainers](https://node.testcontainers.org/).
+The e2e tests start a Fishjam instance via Docker and [Testcontainers](https://node.testcontainers.org/).
 
 #### Colima
 

--- a/e2e/docker-compose-test.yaml
+++ b/e2e/docker-compose-test.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   jellyfish:
-    image: "ghcr.io/jellyfish-dev/jellyfish:${JELLYFISH_VERSION:-0.5.0-rc0}"
+    image: "ghcr.io/fishjam-dev/jellyfish:${JELLYFISH_VERSION:-0.5.0}"
     container_name: jellyfish
     restart: on-failure
     healthcheck:

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -1,19 +1,19 @@
-# Examples for Jellyfish client
+# Examples for Fishjam client
 
 List of examples:
 
-- [minimal](https://github.com/jellyfish-dev/ts-client-sdk/tree/main/examples/minimal) - minimal example of usage of Jellyfish client:
+- [minimal](https://github.com/fishjam-dev/ts-client-sdk/tree/main/examples/minimal) - minimal example of usage of Fishjam client:
 
   - Pure TypeScript
-  - connect to Jellyfish server
+  - connect to Fishjam server
   - join room
   - start broadcasting screen
   - receive media from other peers
   - almost no UI
 
-- [simple-app](https://github.com/jellyfish-dev/ts-client-sdk/tree/main/examples/simple-app) - example of usage of Jellyfish client with vanilla TypeScript:
+- [simple-app](https://github.com/fishjam-dev/ts-client-sdk/tree/main/examples/simple-app) - example of usage of Fishjam client with vanilla TypeScript:
   - Pure TypeScript
-  - connect to Jellyfish server
+  - connect to Fishjam server
   - join room
   - start broadcasting multiple media
   - receive media from other peers

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
 # Fishjam TS client
 
-TypeScript client library for [Fishjam](https://github.com/jellyfish-dev/jellyfish).
+TypeScript client library for [Fishjam](https://github.com/fishjam-dev/fishjam).
 
 ## Documentation
 
-Documentation is available [here](https://jellyfish-dev.github.io/ts-client-sdk/)
+Documentation is available [here](https://fishjam-dev.github.io/ts-client-sdk/)
 
 ## Installation
 
@@ -20,11 +20,11 @@ It was tested with `node.js` version specified in `.tool-versions` file.
 
 Prerequisites:
 
-- Running [Fishjam](https://github.com/jellyfish-dev/jellyfish) server.
+- Running [Fishjam](https://github.com/fishjam-dev/fishjam) server.
 - Created room and token of peer in that room.
-  You u can use [dashboard](https://github.com/jellyfish-dev/jellyfish-react-client/tree/main/examples/dashboard) example to create room and peer token.
+  You u can use [dashboard](https://github.com/fishjam-dev/fishjam-dashboard) example to create room and peer token.
 
-This snippet is based on [minimal](https://github.com/jellyfish-dev/ts-client-sdk/tree/main/examples/minimal) example.
+This snippet is based on [minimal](https://github.com/fishjam-dev/ts-client-sdk/tree/main/examples/minimal) example.
 
 ```ts
 import { JellyfishClient, WebRTCEndpoint } from "@jellyfish-dev/ts-client-sdk";
@@ -105,7 +105,7 @@ async function startScreenSharing(webrtc: WebRTCEndpoint) {
 
 ## Examples
 
-For more examples, see [examples](https://github.com/jellyfish-dev/ts-client-sdk/tree/main/examples) folder.
+For more examples, see [examples](https://github.com/fishjam-dev/ts-client-sdk/tree/main/examples) folder.
 
 ## Contributing
 
@@ -115,20 +115,20 @@ Detailed information about contributing can be found in [contributing.md](./cont
 
 ## Fishjam Ecosystem
 
-|             |                                                                                                                                                                                                                                                              |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Client SDKs | [React](https://github.com/jellyfish-dev/react-client-sdk), [React Native](https://github.com/jellyfish-dev/react-native-client-sdk), [iOs](https://github.com/jellyfish-dev/ios-client-sdk), [Android](https://github.com/jellyfish-dev/android-client-sdk) |
-| Server SDKs | [Elixir](https://github.com/jellyfish-dev/elixir_server_sdk), [Python](https://github.com/jellyfish-dev/python-server-sdk), [OpenAPI](https://jellyfish-dev.github.io/jellyfish-docs/api_reference/rest_api)                                                 |
-| Services    | [Videoroom](https://github.com/jellyfish-dev/jellyfish_videoroom) - an example videoconferencing app written in elixir <br/> [Dashboard](https://github.com/jellyfish-dev/jellyfish-dashboard) - an internal tool used to showcase Fishjam's capabilities  |
-| Resources   | [Fishjam Book](https://jellyfish-dev.github.io/book/) - theory of the framework, [Docs](https://jellyfish-dev.github.io/jellyfish-docs/), [Tutorials](https://github.com/jellyfish-dev/jellyfish-clients-tutorials)                                        |
-| Membrane    | Fishjam is based on [Membrane](https://membrane.stream/), [Discord](https://discord.gg/nwnfVSY)                                                                                                                                                            |
-| Compositor  | [Compositor](https://github.com/membraneframework/membrane_video_compositor_plugin) - Membrane plugin to transform video                                                                                                                                     |
-| Protobufs   | If you want to use Fishjam on your own, you can use our [protobufs](https://github.com/jellyfish-dev/protos)                                                                                                                                               |
+|             |                                                                                                                                                                                                                                                      |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Client SDKs | [React](https://github.com/fishjam-dev/react-client-sdk), [React Native](https://github.com/fishjam-dev/react-native-client-sdk), [iOs](https://github.com/fishjam-dev/ios-client-sdk), [Android](https://github.com/fishjam-dev/android-client-sdk) |
+| Server SDKs | [Elixir](https://github.com/fishjam-dev/elixir_server_sdk), [Python](https://github.com/fishjam-dev/python-server-sdk), [OpenAPI](https://fishjam-dev.github.io/fishjam-docs/api_reference/rest_api)                                                 |
+| Services    | [Videoroom](https://github.com/fishjam-dev/fishjam-videoroom) - an example videoconferencing app written in elixir <br/> [Dashboard](https://github.com/fishjam-dev/fishjam-dashboard) - an internal tool used to showcase Fishjam's capabilities    |
+| Resources   | [Fishjam Book](https://fishjam-dev.github.io/book/) - theory of the framework, [Docs](https://fishjam-dev.github.io/fishjam-docs/), [Tutorials](https://github.com/fishjam-dev/fishjam-clients-tutorials)                                            |
+| Membrane    | Fishjam is based on [Membrane](https://membrane.stream/), [Discord](https://discord.gg/nwnfVSY)                                                                                                                                                      |
+| Compositor  | [Compositor](https://github.com/membraneframework/membrane_video_compositor_plugin) - Membrane plugin to transform video                                                                                                                             |
+| Protobufs   | If you want to use Fishjam on your own, you can use our [protobufs](https://github.com/fishjam-dev/protos)                                                                                                                                           |
 
 ## Copyright and License
 
-Copyright 2023, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=jellyfish)
+Copyright 2023, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=fishjam)
 
-[![Software Mansion](https://logo.swmansion.com/logo?color=white&variant=desktop&width=200&tag=membrane-github)](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=jellyfish)
+[![Software Mansion](https://logo.swmansion.com/logo?color=white&variant=desktop&width=200&tag=membrane-github)](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=fishjam)
 
 Licensed under the [Apache License, Version 2.0](LICENSE)

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-# Jellyfish TS client
+# Fishjam TS client
 
-TypeScript client library for [Jellyfish](https://github.com/jellyfish-dev/jellyfish).
+TypeScript client library for [Fishjam](https://github.com/jellyfish-dev/jellyfish).
 
 ## Documentation
 
@@ -20,7 +20,7 @@ It was tested with `node.js` version specified in `.tool-versions` file.
 
 Prerequisites:
 
-- Running [Jellyfish](https://github.com/jellyfish-dev/jellyfish) server.
+- Running [Fishjam](https://github.com/jellyfish-dev/jellyfish) server.
 - Created room and token of peer in that room.
   You u can use [dashboard](https://github.com/jellyfish-dev/jellyfish-react-client/tree/main/examples/dashboard) example to create room and peer token.
 
@@ -47,7 +47,7 @@ type TrackMetadata = {
   type: "camera" | "screen";
 };
 
-// Creates a new JellyfishClient object to interact with Jellyfish
+// Creates a new FishjamClient object to interact with Fishjam
 const client = new JellyfishClient<PeerMetadata, TrackMetadata>();
 
 const peerToken = prompt("Enter peer token") ?? "YOUR_PEER_TOKEN";
@@ -109,21 +109,21 @@ For more examples, see [examples](https://github.com/jellyfish-dev/ts-client-sdk
 
 ## Contributing
 
-We welcome contributions to Jellyfish Ts Client SDK. Please report any bugs or issues you find or feel free to make a pull request with your own bug fixes and/or features.
+We welcome contributions to Fishjam Ts Client SDK. Please report any bugs or issues you find or feel free to make a pull request with your own bug fixes and/or features.
 
 Detailed information about contributing can be found in [contributing.md](./contributing.md).
 
-## Jellyfish Ecosystem
+## Fishjam Ecosystem
 
 |             |                                                                                                                                                                                                                                                              |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Client SDKs | [React](https://github.com/jellyfish-dev/react-client-sdk), [React Native](https://github.com/jellyfish-dev/react-native-client-sdk), [iOs](https://github.com/jellyfish-dev/ios-client-sdk), [Android](https://github.com/jellyfish-dev/android-client-sdk) |
 | Server SDKs | [Elixir](https://github.com/jellyfish-dev/elixir_server_sdk), [Python](https://github.com/jellyfish-dev/python-server-sdk), [OpenAPI](https://jellyfish-dev.github.io/jellyfish-docs/api_reference/rest_api)                                                 |
-| Services    | [Videoroom](https://github.com/jellyfish-dev/jellyfish_videoroom) - an example videoconferencing app written in elixir <br/> [Dashboard](https://github.com/jellyfish-dev/jellyfish-dashboard) - an internal tool used to showcase Jellyfish's capabilities  |
-| Resources   | [Jellyfish Book](https://jellyfish-dev.github.io/book/) - theory of the framework, [Docs](https://jellyfish-dev.github.io/jellyfish-docs/), [Tutorials](https://github.com/jellyfish-dev/jellyfish-clients-tutorials)                                        |
-| Membrane    | Jellyfish is based on [Membrane](https://membrane.stream/), [Discord](https://discord.gg/nwnfVSY)                                                                                                                                                            |
+| Services    | [Videoroom](https://github.com/jellyfish-dev/jellyfish_videoroom) - an example videoconferencing app written in elixir <br/> [Dashboard](https://github.com/jellyfish-dev/jellyfish-dashboard) - an internal tool used to showcase Fishjam's capabilities  |
+| Resources   | [Fishjam Book](https://jellyfish-dev.github.io/book/) - theory of the framework, [Docs](https://jellyfish-dev.github.io/jellyfish-docs/), [Tutorials](https://github.com/jellyfish-dev/jellyfish-clients-tutorials)                                        |
+| Membrane    | Fishjam is based on [Membrane](https://membrane.stream/), [Discord](https://discord.gg/nwnfVSY)                                                                                                                                                            |
 | Compositor  | [Compositor](https://github.com/membraneframework/membrane_video_compositor_plugin) - Membrane plugin to transform video                                                                                                                                     |
-| Protobufs   | If you want to use Jellyfish on your own, you can use our [protobufs](https://github.com/jellyfish-dev/protos)                                                                                                                                               |
+| Protobufs   | If you want to use Fishjam on your own, you can use our [protobufs](https://github.com/jellyfish-dev/protos)                                                                                                                                               |
 
 ## Copyright and License
 


### PR DESCRIPTION
Update README file to use new name - Fishjam