### PR TITLE
[RTC-556] Only set turn servers once

### DIFF
--- a/src/webrtc/webRTCEndpoint.ts
+++ b/src/webrtc/webRTCEndpoint.ts
@@ -277,14 +277,7 @@ export class WebRTCEndpoint<
     let data;
     switch (deserializedMediaEvent.type) {
       case 'offerData': {
-        const turnServers = deserializedMediaEvent.data.integratedTurnServers;
-        this.setTurns(turnServers);
-
-        const offerData = new Map<string, number>(
-          Object.entries(deserializedMediaEvent.data.tracksTypes),
-        );
-
-        this.onOfferData(offerData);
+        this.onOfferData(deserializedMediaEvent);
         break;
       }
       case 'tracksAdded': {
@@ -1482,8 +1475,11 @@ export class WebRTCEndpoint<
       trackId.startsWith(track),
     );
 
-  private onOfferData = async (offerData: Map<string, number>) => {
+  private onOfferData = async (offerData: MediaEvent) => {
     if (!this.connection) {
+      const turnServers = offerData.data.integratedTurnServers;
+      this.setTurns(turnServers);
+
       this.connection = new RTCPeerConnection(this.rtcConfig);
       this.connection.onicecandidate = this.onLocalCandidate();
       this.connection.onicecandidateerror = this.onIceCandidateError as (
@@ -1513,7 +1509,11 @@ export class WebRTCEndpoint<
       }
     });
 
-    this.addTransceiversIfNeeded(offerData);
+    const tracks = new Map<string, number>(
+      Object.entries(offerData.data.tracksTypes),
+    );
+
+    this.addTransceiversIfNeeded(tracks);
 
     await this.createAndSendOffer();
   };


### PR DESCRIPTION
## Description

So far, whenever we received offerData, we were pushing turnServers to our internal `rtcConfig` array, which is also passed to the PeerConnection at its creation time. 

## Motivation and Context

Setting them just at the beginning should be enough. We would also prevent from memory leak. It's also hard to determine whether rtcConfig array can be safely modified throught session time.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
