### PR TITLE
Reconnect on network change

### DIFF
--- a/src/FishjamClient.ts
+++ b/src/FishjamClient.ts
@@ -78,10 +78,10 @@ export interface MessageEvents<PeerMetadata, TrackMetadata> {
   /** Emitted when the process of reconnection starts */
   reconnectionStarted: () => void;
 
-  /** Emitted when on successful reconnection */
+  /** Emitted on successful reconnection */
   reconnected: () => void;
 
-  /** Emitted when the maximum number of reconnection retries has been reached */
+  /** Emitted when the maximum number of reconnection retries is reached */
   reconnectionFailed: () => void;
 
   /**

--- a/src/FishjamClient.ts
+++ b/src/FishjamClient.ts
@@ -15,6 +15,7 @@ import { EventEmitter } from 'events';
 import { PeerMessage } from './protos';
 import { ReconnectConfig, ReconnectManager } from './reconnection';
 import { AuthErrorReason, isAuthError } from './auth';
+import { Deferred } from './webrtc/deferred';
 
 export type Peer<PeerMetadata, TrackMetadata> = Endpoint<
   PeerMetadata,
@@ -73,6 +74,15 @@ export interface MessageEvents<PeerMetadata, TrackMetadata> {
 
   /** Emitted when the connection is closed */
   disconnected: () => void;
+
+  /** Emitted when the process of reconnection starts */
+  reconnectionStarted: () => void;
+
+  /** Emitted when on successful reconnection */
+  reconnected: () => void;
+
+  /** Emitted when the maximum number of reconnection retries has been reached */
+  reconnectionFailed: () => void;
 
   /**
    * Called when peer was accepted.
@@ -387,9 +397,9 @@ export class FishjamClient<
     this.initConnection(config.peerMetadata);
   }
 
-  private initConnection(peerMetadata: PeerMetadata): void {
+  private async initConnection(peerMetadata: PeerMetadata): Promise<void> {
     if (this.status === 'initialized') {
-      this.disconnect();
+      await this.disconnect();
     }
 
     this.webrtc = new WebRTCEndpoint<PeerMetadata, TrackMetadata>({
@@ -558,7 +568,7 @@ export class FishjamClient<
 
     this.webrtc?.on(
       'connected',
-      (
+      async (
         peerId: string,
         endpointsInRoom: Endpoint<PeerMetadata, TrackMetadata>[],
       ) => {
@@ -571,6 +581,8 @@ export class FishjamClient<
           .map(
             (component) => component as Component<PeerMetadata, TrackMetadata>,
           );
+
+        await this.reconnectManager.handleReconnect()
 
         this.emit('joined', peerId, peers, components);
       },
@@ -1032,6 +1044,10 @@ export class FishjamClient<
 
     this.webrtc.updateTrackMetadata(trackId, trackMetadata);
   };
+
+  public isReconnecting() {
+    return this.reconnectManager.getOngoingReconnectionStatus()
+  }
 
   /**
    * Leaves the room. This function should be called when user leaves the room in a clean way e.g. by clicking a

--- a/src/FishjamClient.ts
+++ b/src/FishjamClient.ts
@@ -82,7 +82,7 @@ export interface MessageEvents<PeerMetadata, TrackMetadata> {
   reconnected: () => void;
 
   /** Emitted when the maximum number of reconnection retries is reached */
-  reconnectionFailed: () => void;
+  reconnectionRetriesLimitReached: () => void;
 
   /**
    * Called when peer was accepted.
@@ -399,7 +399,7 @@ export class FishjamClient<
 
   private async initConnection(peerMetadata: PeerMetadata): Promise<void> {
     if (this.status === 'initialized') {
-      await this.disconnect();
+      this.disconnect();
     }
 
     this.webrtc = new WebRTCEndpoint<PeerMetadata, TrackMetadata>({
@@ -1046,7 +1046,7 @@ export class FishjamClient<
   };
 
   public isReconnecting() {
-    return this.reconnectManager.getOngoingReconnectionStatus();
+    return this.reconnectManager.isReconnecting();
   }
 
   /**

--- a/src/FishjamClient.ts
+++ b/src/FishjamClient.ts
@@ -582,7 +582,7 @@ export class FishjamClient<
             (component) => component as Component<PeerMetadata, TrackMetadata>,
           );
 
-        await this.reconnectManager.handleReconnect()
+        await this.reconnectManager.handleReconnect();
 
         this.emit('joined', peerId, peers, components);
       },
@@ -1046,7 +1046,7 @@ export class FishjamClient<
   };
 
   public isReconnecting() {
-    return this.reconnectManager.getOngoingReconnectionStatus()
+    return this.reconnectManager.getOngoingReconnectionStatus();
   }
 
   /**

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,7 +4,6 @@ export const AUTH_ERROR_REASONS = [
   'expired token',
   'room not found',
   'peer not found',
-  'peer already connected',
 ] as const;
 
 export type AuthErrorReason = (typeof AUTH_ERROR_REASONS)[number];

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export type {
   SignalingUrl,
 } from './FishjamClient';
 
-export type { ReconnectConfig } from './reconnection';
+export type { ReconnectConfig, ReconnectionStatus } from './reconnection';
 
 export type { AuthErrorReason } from './auth.js';
 


### PR DESCRIPTION
## Description

This PR:
- Introduces new events: `reconnectionStarted`, `reconnected`, `reconnectionFailed`
- Exposes the `ongoingReconnection` status
- Waits for all tracks to be added to `RTCPeerConnection` after successful reconnection
- Removes the outdated `peer already connected` auth join reason

## Motivation and Context

It fixes the reconnection mechanism when the user changes the network (e.g., from Wi-Fi to a hotspot). 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)